### PR TITLE
Only capture output for the current thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Capture output written to `System.out` and `System.err`.
 ## Important
 
 Because the `System.out` and `System.err` are implemented as
-singleton's within the JVM, the capturing is not thread-safe. Another
-thread may have it's output captured. This may, or may not, be your
-intended purpose.
+singleton's within the JVM, the capturing is not thread-safe. If two
+instances of `CaptureOutput` are in effect at the same time and are
+not strictly nested (i.e. A starts, B starts, B finishes, A finishes)
+then `System.out` and `System.err` will not be restored properly once
+capturing is finished.

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <properties>
         <junit.version>4.12</junit.version>
         <assertj.version>3.8.0</assertj.version>
+        <mockito.version>2.8.47</mockito.version>
     </properties>
     <parent>
         <groupId>net.kemitix</groupId>
@@ -21,6 +22,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
         <assertj.version>3.8.0</assertj.version>
         <mockito.version>2.8.47</mockito.version>
 
+        <pitest.coverage>100</pitest.coverage>
+        <pitest.mutation>100</pitest.mutation>
         <jacoco-class-line-covered-ratio>1</jacoco-class-line-covered-ratio>
         <jacoco-class-instruction-covered-ratio>1</jacoco-class-instruction-covered-ratio>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,9 @@
         <junit.version>4.12</junit.version>
         <assertj.version>3.8.0</assertj.version>
         <mockito.version>2.8.47</mockito.version>
+
+        <jacoco-class-line-covered-ratio>1</jacoco-class-line-covered-ratio>
+        <jacoco-class-instruction-covered-ratio>1</jacoco-class-instruction-covered-ratio>
     </properties>
     <parent>
         <groupId>net.kemitix</groupId>

--- a/src/main/java/net/kemitix/outputcapture/CaptureOutput.java
+++ b/src/main/java/net/kemitix/outputcapture/CaptureOutput.java
@@ -47,14 +47,15 @@ public final class CaptureOutput implements OutputCapturer {
     private CapturedOutput capture(
             final Runnable runnable, final Router router
                                   ) {
-        final ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
-        final ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
-        final PrintStream originalOut = capturePrintStream(System.out, capturedOut, router, System::setOut);
-        final PrintStream originalErr = capturePrintStream(System.err, capturedErr, router, System::setErr);
+        final CapturedPrintStream capturedOut = capturePrintStream(System.out, router, System::setOut);
+        final CapturedPrintStream capturedErr = capturePrintStream(System.err, router, System::setErr);
         runnable.run();
-        System.setOut(originalOut);
-        System.setErr(originalErr);
-        return asCapturedOutput(capturedOut, capturedErr);
+        if (System.out != capturedOut.getReplacementStream()) {
+            throw new OutputCaptureException("System.out has been replaced");
+        }
+        System.setOut(capturedOut.getOriginalStream());
+        System.setErr(capturedErr.getOriginalStream());
+        return asCapturedOutput(capturedOut.getCapturedTo(), capturedErr.getCapturedTo());
     }
 
     private CapturedOutput asCapturedOutput(
@@ -74,15 +75,12 @@ public final class CaptureOutput implements OutputCapturer {
         };
     }
 
-    private PrintStream capturePrintStream(
-            final PrintStream originalStream, final ByteArrayOutputStream captureTo, final Router router,
-            final Consumer<PrintStream> setStream
-                                          ) {
-        final PrintStream capturingStream = new PrintStream(captureTo);
-        final PrintStream filteredStream = new ThreadFilteredPrintStream(capturingStream, Thread.currentThread());
-        final PrintStream routedStream = router.handle(filteredStream, originalStream);
-        setStream.accept(routedStream);
-        return originalStream;
+    private CapturedPrintStream capturePrintStream(
+            final PrintStream originalStream, final Router router, final Consumer<PrintStream> setStream
+                                                  ) {
+        final CapturedPrintStream capturedPrintStream = new CapturedPrintStream(originalStream, router);
+        setStream.accept(capturedPrintStream.getReplacementStream());
+        return capturedPrintStream;
     }
 
     private Stream<String> asStream(final ByteArrayOutputStream captured) {
@@ -90,45 +88,4 @@ public final class CaptureOutput implements OutputCapturer {
                                      .split(System.lineSeparator()));
     }
 
-    /**
-     * Routes output between the capturing stream and the original stream.
-     *
-     * @see {@link RedirectRouter}
-     * @see {@link CopyRouter}
-     */
-    private interface Router {
-
-        /**
-         * Create an output stream that routes the output to the appropriate stream(s).
-         *
-         * @param capturingStream the stream capturing the output
-         * @param originalStream  the stream where output would normally have gone
-         *
-         * @return a PrintStream to be used to write to
-         */
-        PrintStream handle(PrintStream capturingStream, PrintStream originalStream);
-
-    }
-
-    /**
-     * Router that redirects output away from the original output stream to the capturing stream.
-     */
-    private class RedirectRouter implements Router {
-
-        @Override
-        public PrintStream handle(final PrintStream capturingStream, final PrintStream originalStream) {
-            return capturingStream;
-        }
-    }
-
-    /**
-     * Router the copies the output to both the original output stream and the capturing stream.
-     */
-    private class CopyRouter implements Router {
-
-        @Override
-        public PrintStream handle(final PrintStream capturingStream, final PrintStream originalStream) {
-            return new TeeOutputStream(capturingStream, originalStream);
-        }
-    }
 }

--- a/src/main/java/net/kemitix/outputcapture/CaptureOutput.java
+++ b/src/main/java/net/kemitix/outputcapture/CaptureOutput.java
@@ -79,7 +79,8 @@ public final class CaptureOutput implements OutputCapturer {
             final Consumer<PrintStream> setStream
                                           ) {
         final PrintStream capturingStream = new PrintStream(captureTo);
-        final PrintStream routedStream = router.handle(capturingStream, originalStream);
+        final PrintStream filteredStream = new ThreadFilteredPrintStream(capturingStream, Thread.currentThread());
+        final PrintStream routedStream = router.handle(filteredStream, originalStream);
         setStream.accept(routedStream);
         return originalStream;
     }

--- a/src/main/java/net/kemitix/outputcapture/CapturedPrintStream.java
+++ b/src/main/java/net/kemitix/outputcapture/CapturedPrintStream.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.outputcapture;
+
+import lombok.Getter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * Holder for the original stream and its replacement.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+class CapturedPrintStream {
+
+    @Getter
+    private final PrintStream originalStream;
+
+    @Getter
+    private final PrintStream replacementStream;
+
+    @Getter
+    private final ByteArrayOutputStream capturedTo;
+
+    /**
+     * Constructor.
+     *
+     * @param originalStream The original stream
+     * @param router         The output router
+     */
+    CapturedPrintStream(final PrintStream originalStream, final Router router) {
+        this.originalStream = originalStream;
+        this.capturedTo = new ByteArrayOutputStream();
+        final PrintStream capturingStream = new PrintStream(this.capturedTo);
+        final PrintStream filteredStream = new ThreadFilteredPrintStream(capturingStream, Thread.currentThread());
+        this.replacementStream = router.handle(filteredStream, originalStream);
+    }
+}

--- a/src/main/java/net/kemitix/outputcapture/CopyRouter.java
+++ b/src/main/java/net/kemitix/outputcapture/CopyRouter.java
@@ -1,0 +1,37 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.outputcapture;
+
+import java.io.PrintStream;
+
+/**
+ * Router the copies the output to both the original output stream and the capturing stream.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+class CopyRouter implements Router {
+
+    @Override
+    public PrintStream handle(final PrintStream capturingStream, final PrintStream originalStream) {
+        return new TeeOutputStream(capturingStream, originalStream);
+    }
+}

--- a/src/main/java/net/kemitix/outputcapture/OutputCaptureException.java
+++ b/src/main/java/net/kemitix/outputcapture/OutputCaptureException.java
@@ -1,0 +1,39 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.outputcapture;
+
+/**
+ * Thrown when there is an error capturing output or restoring system outputs.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public class OutputCaptureException extends RuntimeException {
+
+    /**
+     * Constructor.
+     *
+     * @param message The message
+     */
+    public OutputCaptureException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/kemitix/outputcapture/RedirectRouter.java
+++ b/src/main/java/net/kemitix/outputcapture/RedirectRouter.java
@@ -1,0 +1,37 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.outputcapture;
+
+import java.io.PrintStream;
+
+/**
+ * Router that redirects output away from the original output stream to the capturing stream.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+class RedirectRouter implements Router {
+
+    @Override
+    public PrintStream handle(final PrintStream capturingStream, final PrintStream originalStream) {
+        return capturingStream;
+    }
+}

--- a/src/main/java/net/kemitix/outputcapture/Router.java
+++ b/src/main/java/net/kemitix/outputcapture/Router.java
@@ -1,0 +1,46 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.outputcapture;
+
+import java.io.PrintStream;
+
+/**
+ * Routes output between the capturing stream and the original stream.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ *
+ * @see {@link RedirectRouter}
+ * @see {@link CopyRouter}
+ */
+interface Router {
+
+    /**
+     * Create an output stream that routes the output to the appropriate stream(s).
+     *
+     * @param capturingStream the stream capturing the output
+     * @param originalStream  the stream where output would normally have gone
+     *
+     * @return a PrintStream to be used to write to
+     */
+    PrintStream handle(PrintStream capturingStream, PrintStream originalStream);
+
+}

--- a/src/main/java/net/kemitix/outputcapture/ThreadFilteredPrintStream.java
+++ b/src/main/java/net/kemitix/outputcapture/ThreadFilteredPrintStream.java
@@ -29,7 +29,7 @@ import java.io.PrintStream;
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class ThreadFilteredPrintStream extends PrintStream {
+class ThreadFilteredPrintStream extends PrintStream {
 
     private final Thread filteredThread;
 
@@ -39,7 +39,7 @@ public class ThreadFilteredPrintStream extends PrintStream {
      * @param out            The output stream
      * @param filteredThread The thread to filter on
      */
-    public ThreadFilteredPrintStream(final OutputStream out, final Thread filteredThread) {
+    ThreadFilteredPrintStream(final OutputStream out, final Thread filteredThread) {
         super(out);
         this.filteredThread = filteredThread;
     }

--- a/src/main/java/net/kemitix/outputcapture/ThreadFilteredPrintStream.java
+++ b/src/main/java/net/kemitix/outputcapture/ThreadFilteredPrintStream.java
@@ -1,0 +1,77 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.outputcapture;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * Filters output to a PrintStream to output written from the filtering thread.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public class ThreadFilteredPrintStream extends PrintStream {
+
+    private final Thread filteredThread;
+
+    /**
+     * Constructor.
+     *
+     * @param out            The output stream
+     * @param filteredThread The thread to filter on
+     */
+    public ThreadFilteredPrintStream(final OutputStream out, final Thread filteredThread) {
+        super(out);
+        this.filteredThread = filteredThread;
+    }
+
+    /**
+     * Writes the specified byte to all streams.
+     *
+     * @param b The byte to be written
+     */
+    @Override
+    public void write(final int b) {
+        if (onFilteredThread()) {
+            super.write(b);
+        }
+    }
+
+    /**
+     * Writes <code>len</code> bytes from the specified byte array starting at offset <code>off</code> to all streams.
+     *
+     * @param buf A byte array
+     * @param off Offset from which to start taking bytes
+     * @param len Number of bytes to write
+     */
+    @Override
+    public void write(final byte[] buf, final int off, final int len) {
+        if (onFilteredThread()) {
+            super.write(buf, off, len);
+        }
+    }
+
+    private boolean onFilteredThread() {
+        return Thread.currentThread()
+                     .equals(filteredThread);
+    }
+}

--- a/src/test/java/net/kemitix/outputcapture/CaptureTest.java
+++ b/src/test/java/net/kemitix/outputcapture/CaptureTest.java
@@ -167,11 +167,12 @@ public class CaptureTest {
         runOnThreadAndWait(() -> {
             capturedOutput.set(captureOutput.of(() -> {
                 System.out.println("message");
+                System.out.write('x');
             }));
         });
         //then
         assertThat(capturedOutput.get()
-                                 .getStdOut()).containsExactly("message");
+                                 .getStdOut()).containsExactly("message", "x");
     }
 
     @Test
@@ -182,6 +183,7 @@ public class CaptureTest {
         final CapturedOutput capturedOutput = captureOutput.of(() -> {
             runOnThreadAndWait(() -> {
                 System.out.println("message");
+                System.out.write('x');
             });
         });
         //then

--- a/src/test/java/net/kemitix/outputcapture/CaptureTest.java
+++ b/src/test/java/net/kemitix/outputcapture/CaptureTest.java
@@ -1,3 +1,4 @@
+
 /**
  * The MIT License (MIT)
  *
@@ -19,6 +20,7 @@
 
 package net.kemitix.outputcapture;
 
+import lombok.SneakyThrows;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Test;
@@ -216,14 +218,11 @@ public class CaptureTest {
         }
     }
 
+    @SneakyThrows
     private void runOnThreadAndWait(final Runnable runnable) {
         final Thread thread = new Thread(runnable);
         thread.start();
-        try {
-            thread.join();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        thread.join();
     }
 
     private String randomText() {


### PR DESCRIPTION
Ignore output written to `System.out` and `System.err` from other threads.